### PR TITLE
fix: loader is not cacheable

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -10,7 +10,8 @@ const store = require('./store');
 const plugin = require('./postcss');
 
 module.exports = function(source) {
-
+    this.cacheable(false);
+    
     // make loader async
     const cb = this.async();
 


### PR DESCRIPTION
This marks the loader as being uncacheable, guaranteeing that it will be run on every compilation. This might be brutish but it does fix the issue.